### PR TITLE
Enhancement: Require phpstan/phpstan-deprecation-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "localheinz/phpstan-rules": "~0.5.0",
     "localheinz/test-util": "~0.7.0",
     "phpstan/phpstan": "~0.10.7",
+    "phpstan/phpstan-deprecation-rules": "~0.10.2",
     "phpstan/phpstan-strict-rules": "~0.10.1",
     "phpunit/phpunit": "^7.5.1"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65261b5b2c1664c41ff03660480edd8b",
+    "content-hash": "96a39522a50dd73ee10c3ea9d1300da2",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2949,6 +2949,52 @@
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "time": "2018-12-28T13:47:37+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "0.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "fc7d373a760d2bf5cf999b052072adfa728892a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/fc7d373a760d2bf5cf999b052072adfa728892a0",
+                "reference": "fc7d373a760d2bf5cf999b052072adfa728892a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "~7.1",
+                "phpstan/phpstan": "^0.10"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.0.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan-phpunit": "^0.10",
+                "phpunit/phpunit": "^7.0",
+                "slevomat/coding-standard": "^4.5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "time": "2018-06-30T14:42:51+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
 	- vendor/localheinz/phpstan-rules/rules.neon
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 

--- a/test/Unit/ComposerJsonNormalizerTest.php
+++ b/test/Unit/ComposerJsonNormalizerTest.php
@@ -51,7 +51,6 @@ final class ComposerJsonNormalizerTest extends AbstractNormalizerTestCase
         $schemaNormalizer = \array_shift($chainedNormalizers);
 
         self::assertInstanceOf(SchemaNormalizer::class, $schemaNormalizer);
-        self::assertAttributeSame('https://getcomposer.org/schema.json', 'schemaUri', $schemaNormalizer);
     }
 
     public function testNormalizeNormalizes(): void


### PR DESCRIPTION
This PR

* [x] requires `phpstan/phpstan-deprecation-rules`
* [x] includes `rules.neon` from `phpstan/phpstan-deprecation-rules`
* [x] removes a deprecated assertion