### PR TITLE
Enhancement: Use ergebnis/json-normalizer instead of localheinz/json-normalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.0.2...master`][1.0.2...master].
 
+### Changed
+
+* Started using `ergebnis/json-normalizer` instead of `localheinz/json-normalizer` ([#44]), by [@localheinz]
+
 ### Fixed
 
 * Dropped support for PHP 7.1 ([#30]), by [@localheinz]
@@ -51,5 +55,6 @@ For a full diff see [`149a393...1.0.0`][149a393...1.0.0].
 [#21]: https://github.com/localheinz/composer-json-normalizer/pull/21
 [#30]: https://github.com/localheinz/composer-json-normalizer/pull/30
 [#41]: https://github.com/localheinz/composer-json-normalizer/pull/41
+[#44]: https://github.com/localheinz/composer-json-normalizer/pull/44
 
 [@localheinz]: https://github.com/localheinz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`1.0.2...master`][1.0.2...master].
 
 * Dropped support for PHP 7.1 ([#30]), by [@localheinz]
 * Required implicit dependency `ext-json` explicitly ([#41]), by [@localheinz]
+* Required implicit dependency `justinrainbow/json-schema` explicitly ([#44]), by [@localheinz]
 
 ## [`1.0.2`][1.0.2]
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ and use it to normalize the contents of a `composer.json`:
 ```php
 <?php
 
+use Ergebnis\Json\Normalizer\Json;
 use Localheinz\Composer\Json\Normalizer\ComposerJsonNormalizer;
-use Localheinz\Json\Normalizer\Json;
 
 $normalizer = new ComposerJsonNormalizer();
 
@@ -41,8 +41,8 @@ echo $normalized->encoded();
 
 The `ComposerJsonNormalizer` composes normalizers provided by [`localheinz/json-normalizer`](https://github.com/localheinz/json-normalizer):
 
-* [`Localheinz\Json\Normalizer\ChainNormalizer`](https://github.com/localheinz/json-normalizer#chainnormalizer)
-* [`Localheinz\Json\Normalizer\SchemaNormalizer`](https://github.com/localheinz/json-normalizer#schemanormalizer)
+* [`Ergebnis\Json\Normalizer\ChainNormalizer`](https://github.com/localheinz/json-normalizer#chainnormalizer)
+* [`Ergebnis\Json\Normalizer\SchemaNormalizer`](https://github.com/localheinz/json-normalizer#schemanormalizer)
 
 as well as the following normalizers provided by this package:
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
   "require": {
     "php": "^7.2",
     "ext-json": "*",
-    "ergebnis/json-normalizer": "~0.10.0"
+    "ergebnis/json-normalizer": "~0.10.0",
+    "justinrainbow/json-schema": "^4.0.0 || ^5.0.0"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": "^7.2",
     "ext-json": "*",
-    "localheinz/json-normalizer": "~0.9.0"
+    "ergebnis/json-normalizer": "~0.10.0"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5229f7fcbc1d0d8dec71492fc32eef07",
+    "content-hash": "12c8272cf61cb9286ed1adbc0cbc5683",
     "packages": [
         {
             "name": "ergebnis/json-normalizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,121 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e268f0a1208f90895c7eaf4f164b8d20",
+    "content-hash": "5229f7fcbc1d0d8dec71492fc32eef07",
     "packages": [
+        {
+            "name": "ergebnis/json-normalizer",
+            "version": "0.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-normalizer.git",
+                "reference": "a489b84d68f0e8a8c882a849550312a6e0c9b7f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/a489b84d68f0e8a8c882a849550312a6e0c9b7f0",
+                "reference": "a489b84d68f0e8a8c882a849550312a6e0c9b7f0",
+                "shasum": ""
+            },
+            "require": {
+                "ergebnis/json-printer": "^3.0.1",
+                "ext-json": "*",
+                "justinrainbow/json-schema": "^4.0.0 || ^5.0.0",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "ergebnis/php-cs-fixer-config": "~1.1.1",
+                "ergebnis/phpstan-rules": "~0.14.1",
+                "ergebnis/test-util": "~0.9.0",
+                "infection/infection": "~0.13.6",
+                "jangregor/phpstan-prophecy": "~0.4.2",
+                "phpbench/phpbench": "~0.16.10",
+                "phpstan/extension-installer": "^1.0.3",
+                "phpstan/phpstan": "~0.11.19",
+                "phpstan/phpstan-deprecation-rules": "~0.11.2",
+                "phpstan/phpstan-strict-rules": "~0.11.1",
+                "phpunit/phpunit": "^8.5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\Normalizer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides normalizers for normalizing JSON documents.",
+            "homepage": "https://github.com/ergebnis/json-normalizer",
+            "keywords": [
+                "json",
+                "normalizer"
+            ],
+            "time": "2019-12-15T11:48:50+00:00"
+        },
+        {
+            "name": "ergebnis/json-printer",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-printer.git",
+                "reference": "182fe2f4223e40ba4f1ca2ccdb35e2dd8c1e0878"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-printer/zipball/182fe2f4223e40ba4f1ca2ccdb35e2dd8c1e0878",
+                "reference": "182fe2f4223e40ba4f1ca2ccdb35e2dd8c1e0878",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "ergebnis/php-cs-fixer-config": "~1.1.0",
+                "ergebnis/phpstan-rules": "~0.14.0",
+                "ergebnis/test-util": "~0.9.0",
+                "infection/infection": "~0.13.6",
+                "phpbench/phpbench": "~0.16.10",
+                "phpstan/extension-installer": "^1.0.3",
+                "phpstan/phpstan": "~0.11.19",
+                "phpstan/phpstan-deprecation-rules": "~0.11.2",
+                "phpstan/phpstan-strict-rules": "~0.11.1",
+                "phpunit/phpunit": "^8.5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\Printer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a JSON printer, allowing for flexible indentation.",
+            "homepage": "https://github.com/ergebnis/json-printer",
+            "keywords": [
+                "formatter",
+                "json",
+                "printer"
+            ],
+            "time": "2019-12-15T09:53:05+00:00"
+        },
         {
             "name": "justinrainbow/json-schema",
             "version": "5.2.9",
@@ -71,109 +184,6 @@
                 "schema"
             ],
             "time": "2019-09-25T14:49:45+00:00"
-        },
-        {
-            "name": "localheinz/json-normalizer",
-            "version": "0.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/localheinz/json-normalizer.git",
-                "reference": "28eeda6f1f0daa3c9c28ad0651d95478fe1a5059"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/json-normalizer/zipball/28eeda6f1f0daa3c9c28ad0651d95478fe1a5059",
-                "reference": "28eeda6f1f0daa3c9c28ad0651d95478fe1a5059",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "justinrainbow/json-schema": "^4.0.0 || ^5.0.0",
-                "localheinz/json-printer": "^2.0.1",
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "infection/infection": "~0.10.5",
-                "localheinz/php-cs-fixer-config": "~1.15.0",
-                "localheinz/test-util": "~0.7.0",
-                "phpbench/phpbench": "~0.14.0",
-                "phpstan/phpstan": "~0.10.3",
-                "phpunit/phpunit": "^7.4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Localheinz\\Json\\Normalizer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides normalizers for normalizing JSON documents.",
-            "homepage": "https://github.com/localheinz/json-normalizer",
-            "keywords": [
-                "json",
-                "normalizer"
-            ],
-            "abandoned": "ergebnis/json-normalizer",
-            "time": "2018-10-07T17:36:39+00:00"
-        },
-        {
-            "name": "localheinz/json-printer",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/localheinz/json-printer.git",
-                "reference": "86f942599c8f9f922de4e21c2b9b6564c895cb0c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/json-printer/zipball/86f942599c8f9f922de4e21c2b9b6564c895cb0c",
-                "reference": "86f942599c8f9f922de4e21c2b9b6564c895cb0c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "infection/infection": "~0.8.1",
-                "localheinz/php-cs-fixer-config": "~1.14.0",
-                "localheinz/test-util": "0.6.1",
-                "phpbench/phpbench": "~0.14.0",
-                "phpunit/phpunit": "^6.5.7"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Localheinz\\Json\\Printer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides a JSON printer, allowing for flexible indentation.",
-            "homepage": "https://github.com/localheinz/json-printer",
-            "keywords": [
-                "formatter",
-                "json",
-                "printer"
-            ],
-            "abandoned": "ergebnis/json-printer",
-            "time": "2018-08-11T23:54:50+00:00"
         }
     ],
     "packages-dev": [

--- a/src/BinNormalizer.php
+++ b/src/BinNormalizer.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Localheinz\Composer\Json\Normalizer;
 
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\NormalizerInterface;
 
 final class BinNormalizer implements NormalizerInterface
 {

--- a/src/ComposerJsonNormalizer.php
+++ b/src/ComposerJsonNormalizer.php
@@ -13,22 +13,25 @@ declare(strict_types=1);
 
 namespace Localheinz\Composer\Json\Normalizer;
 
-use Localheinz\Json\Normalizer\ChainNormalizer;
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NormalizerInterface;
-use Localheinz\Json\Normalizer\SchemaNormalizer;
+use Ergebnis\Json\Normalizer;
+use JsonSchema\SchemaStorage;
+use JsonSchema\Validator;
 
-final class ComposerJsonNormalizer implements NormalizerInterface
+final class ComposerJsonNormalizer implements Normalizer\NormalizerInterface
 {
     /**
-     * @var NormalizerInterface
+     * @var Normalizer\NormalizerInterface
      */
     private $normalizer;
 
     public function __construct(string $schemaUri = 'https://getcomposer.org/schema.json')
     {
-        $this->normalizer = new ChainNormalizer(
-            new SchemaNormalizer($schemaUri),
+        $this->normalizer = new Normalizer\ChainNormalizer(
+            new Normalizer\SchemaNormalizer(
+                $schemaUri,
+                new SchemaStorage(),
+                new Normalizer\Validator\SchemaValidator(new Validator())
+            ),
             new BinNormalizer(),
             new ConfigHashNormalizer(),
             new PackageHashNormalizer(),
@@ -36,7 +39,7 @@ final class ComposerJsonNormalizer implements NormalizerInterface
         );
     }
 
-    public function normalize(Json $json): Json
+    public function normalize(Normalizer\Json $json): Normalizer\Json
     {
         if (!\is_object($json->decoded())) {
             return $json;

--- a/src/ConfigHashNormalizer.php
+++ b/src/ConfigHashNormalizer.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Localheinz\Composer\Json\Normalizer;
 
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\NormalizerInterface;
 
 final class ConfigHashNormalizer implements NormalizerInterface
 {

--- a/src/PackageHashNormalizer.php
+++ b/src/PackageHashNormalizer.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Localheinz\Composer\Json\Normalizer;
 
 use Composer\Repository;
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\NormalizerInterface;
 
 final class PackageHashNormalizer implements NormalizerInterface
 {

--- a/src/VersionConstraintNormalizer.php
+++ b/src/VersionConstraintNormalizer.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Localheinz\Composer\Json\Normalizer;
 
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\NormalizerInterface;
 
 final class VersionConstraintNormalizer implements NormalizerInterface
 {

--- a/test/Unit/AbstractNormalizerTestCase.php
+++ b/test/Unit/AbstractNormalizerTestCase.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\NormalizerInterface;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NormalizerInterface;
 use PHPUnit\Framework;
 
 /**

--- a/test/Unit/BinNormalizerTest.php
+++ b/test/Unit/BinNormalizerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Normalizer\Json;
 use Localheinz\Composer\Json\Normalizer\BinNormalizer;
-use Localheinz\Json\Normalizer\Json;
 
 /**
  * @internal
@@ -76,7 +76,7 @@ JSON
   "foo": {
     "qux": "quux",
     "bar": "baz"
-  }  
+  }
 }
 JSON
         );

--- a/test/Unit/ComposerJsonNormalizerTest.php
+++ b/test/Unit/ComposerJsonNormalizerTest.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 
 namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Normalizer\ChainNormalizer;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\SchemaNormalizer;
 use Localheinz\Composer\Json\Normalizer\BinNormalizer;
 use Localheinz\Composer\Json\Normalizer\ComposerJsonNormalizer;
 use Localheinz\Composer\Json\Normalizer\ConfigHashNormalizer;
 use Localheinz\Composer\Json\Normalizer\PackageHashNormalizer;
 use Localheinz\Composer\Json\Normalizer\VersionConstraintNormalizer;
-use Localheinz\Json\Normalizer\ChainNormalizer;
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NormalizerInterface;
-use Localheinz\Json\Normalizer\SchemaNormalizer;
 
 /**
  * @internal

--- a/test/Unit/ConfigHashNormalizerTest.php
+++ b/test/Unit/ConfigHashNormalizerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Normalizer\Json;
 use Localheinz\Composer\Json\Normalizer\ConfigHashNormalizer;
-use Localheinz\Json\Normalizer\Json;
 
 /**
  * @internal
@@ -82,7 +82,7 @@ JSON
   "foo": {
     "qux": "quux",
     "bar": "baz"
-  }  
+  }
 }
 JSON
         );

--- a/test/Unit/PackageHashNormalizerTest.php
+++ b/test/Unit/PackageHashNormalizerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Normalizer\Json;
 use Localheinz\Composer\Json\Normalizer\PackageHashNormalizer;
-use Localheinz\Json\Normalizer\Json;
 
 /**
  * @internal

--- a/test/Unit/VersionConstraintNormalizerTest.php
+++ b/test/Unit/VersionConstraintNormalizerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Localheinz\Composer\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Normalizer\Json;
 use Localheinz\Composer\Json\Normalizer\VersionConstraintNormalizer;
-use Localheinz\Json\Normalizer\Json;
 
 /**
  * @internal


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/json-normalizer` instead of `localheinz/json-normalizer`
* [x] requires `justinrainbow/json-schema`